### PR TITLE
Fix Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM node:boron
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+COPY . /usr/src/app/
+
 # Install app dependencies
-COPY package.json yarn.lock /usr/src/app/
 RUN yarn
 
 VOLUME  /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/usr/src/app
+      - ./data:/usr/src/app/data


### PR DESCRIPTION
In Docker, when setting an existing folder as a volume it "links" the
host folder with the one inside the container, making the changes made
during build futile.

The application is installed when creating the image not running it, the
reason for this is to increase flexibility for various setups (ex. Kubernetes)